### PR TITLE
add flexible unicode encoding options; add max_cells/split_word to multi_cell; remove debugging

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -45,3 +45,4 @@ nosetests.xml
 .mr.developer.cfg
 .project
 .pydevproject
+.idea

--- a/fpdf/fpdf.py
+++ b/fpdf/fpdf.py
@@ -1643,7 +1643,8 @@ class FPDF(object):
                     if not e.errno == errno.EACCES:
                         raise  # Not a permission error.
 
-            if cid > 255 and (cid not in subset): continue
+            if (cid > 255 and (cid not in subset)) or (cid not in font['cw']):
+                continue
             width = font['cw'][cid]
             if (width == 0): continue
             if (width == 65535): width = 0

--- a/fpdf/fpdf.py
+++ b/fpdf/fpdf.py
@@ -1627,6 +1627,7 @@ class FPDF(object):
 
         # for each character
         subset = set(font['subset'])
+        print('startcid {} cwlen {}'.format(startcid, cwlen))
         for cid in range(startcid, cwlen):
             if cid == 128 and cw127fname and not os.path.exists(cw127fname):
                 try:
@@ -1643,9 +1644,15 @@ class FPDF(object):
                     if not e.errno == errno.EACCES:
                         raise  # Not a permission error.
 
-            if (cid > 255 and (cid not in subset)) or (cid not in font['cw']):
+            if cid > 255 and (cid not in subset):
                 continue
-            width = font['cw'][cid]
+            try:
+                width = font['cw'][cid]
+            except IndexError:
+                print('cid {} not found'.format(cid))
+                print(font['cw'].__class__.__name__)
+                print(len(font['cw']))
+                width = 0
             if (width == 0): continue
             if (width == 65535): width = 0
 


### PR DESCRIPTION
1) removed some debugging statements and some code that was commented out
2) for Python < 3 users, added the ability to specify the target encoding as well as the encoding mode. It defaults to the original hardcoded values of `latin1` and `ignore`
3) added a `multiline_max_cells` element attribute for `Template` and corresponding `max_cells` parameter for the `multi_cell` method to allow users to specify the maximum number of cells wrapped text should occupy.
4) added a `multiline_split_word` element attribute for `Template` and corresponding `split_word` parameter for the `multi_cell` method to allow users to choose to split words when using `multiline` `False`. The effect of this is that for the string 'Foo Barbazverylongunbreakablesecondword', instead of getting just 'Foo', you will get 'Foo Barbazverylongu'.