### PR TITLE
Centering of html images incorrrectly offsets the x pos

### DIFF
--- a/fpdf/html.py
+++ b/fpdf/html.py
@@ -268,7 +268,7 @@ class HTML2FPDF(HTMLParser):
                 w = px2mm(attrs.get('width', 0))
                 h = px2mm(attrs.get('height',0))
                 if self.align and self.align[0].upper() == 'C':
-                    x = (self.pdf.w-x)/2.0 - w/2.0
+                    x = self.pdf.w/2.0 - w/2.0
                 self.pdf.image(self.image_map(attrs['src']),
                                x, y, w, h, link=self.href)
                 self.pdf.set_x(x+w)

--- a/test/html_test.py
+++ b/test/html_test.py
@@ -1,0 +1,28 @@
+import fpdf
+import os
+import unittest
+
+
+class MyFPDF(fpdf.FPDF, fpdf.HTMLMixin):
+  pass
+
+
+class HTMLTest(unittest.TestCase):
+  """This test executes some possible inputs to FPDF#HTMLMixin."""
+  def test_html_images(self):
+    pdf = MyFPDF()
+    pdf.add_page()
+    img_path = f"{os.path.dirname(os.path.abspath(__file__))}/image/png_images/c636287a4d7cb1a36362f7f236564cef.png"
+    self.assertEqual(round(pdf.get_x()), 10, 'Initial x margin is not expected')
+    self.assertEqual(round(pdf.get_y()), 10, 'Initial y margin is not expected')
+    self.assertEqual(round(pdf.w), 210, 'Page width is not expected')
+    pdf.write_html(f"<center><img src={img_path} height='300' width='300'></center>")
+    # Unable to text position of the image as write html moves to a new line after
+    # adding the image but it can be seen in the produce test.pdf file.
+    self.assertEqual(round(pdf.get_x()), 10, 'Have not moved to beginning of new line')
+    self.assertEqual(round(pdf.get_y()), 116, 'Image height has moved down the page')
+    pdf.output('test/test.pdf', "F")
+
+
+if __name__ == '__main__':
+  unittest.main()


### PR DESCRIPTION
When positioning an image and align is set to center a new x position is calculated.

It might just be a bug but the current behaviour seems to be that it calculates the distance from the current x to the center of the page width remaining before taking the image width in to account. If the intent was to take the margins in to account then it's ignoring the right margin.

In order to center an image in the page the current value for x should be ignored which is what this change does.